### PR TITLE
fix(teacherworkspace): 学年格式校验，合并来自其他人的提交

### DIFF
--- a/wuyu-server/src/main/java/com/fiveup/core/teacherworkspace/service/impl/LessonServiceImpl.java
+++ b/wuyu-server/src/main/java/com/fiveup/core/teacherworkspace/service/impl/LessonServiceImpl.java
@@ -80,6 +80,9 @@ public class LessonServiceImpl extends ServiceImpl<LessonMapper, Lesson> impleme
         if (semester < 1 || semester > 2) {
             throw new RuntimeException("请选择正确的学期");
         }
+        if (!RegexVerifyUtils.validAcademicYear(academicYear)) {
+            throw new ApiException("学年格式错误");
+        }
 
         // 查询目标
         LambdaQueryWrapper<Lesson> targetQuery = new LambdaQueryWrapper<>();
@@ -163,6 +166,9 @@ public class LessonServiceImpl extends ServiceImpl<LessonMapper, Lesson> impleme
 
     @Override
     public int setCurrentByAcademicAndSemester(String academicYear, int semester) {
+        if (!RegexVerifyUtils.validAcademicYear(academicYear)) {
+            throw new ApiException("学年格式错误");
+        }
         // 如果有性能问题，可以改成流式查询
         LambdaUpdateWrapper<Lesson> setWrapper = new LambdaUpdateWrapper<>();
         setWrapper

--- a/wuyu-server/src/main/resources/application.yml
+++ b/wuyu-server/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
     name: fiveup-core
   jackson:
     default-property-inclusion: non_null # springboot默认解析对象为json对象时属性值为null时不予显示此属性
+  redis:
+    host: 172.21.143.74 # Redis服务器地址
+    database: 0 # Redis数据库索引（默认为0）
+    port: 6379 # Redis服务器连接端口
+    password: root # Redis服务器连接密码（默认为空）
+    timeout: 300ms # 连接超时时间（毫秒）
   datasource:
     url: jdbc:mysql://49.51.69.99:3306/fiveup?useUnicode=true&characterEncoding=utf-8&serverTimezone=Asia/Shanghai&serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
     username: Wuyu_Developer


### PR DESCRIPTION
- 在 LessonServiceImpl 类中的 setCurrentByAcademicAndSemester 和 getCurrentByAcademicAndSemester 方法中添加了学年格式校验
- 使用 RegexVerifyUtils.validAcademicYear 方法进行学年格式验证
- 如果学年格式不正确，抛出 ApiException 异常